### PR TITLE
Suggestions from @tgdl and code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Frisquet Boiler for ESPHome
 
-This ESPHome component allows to use an ESPHome device
-(ESP8266 or ESP32) to control a [Frisquet](<https://www.frisquet.com/en>) heating boiler, replacing the Eco Radio System remote thermostat.
+This ESPHome component allows to use an ESPHome device (ESP8266 or ESP32) to control a [Frisquet](<https://www.frisquet.com/en>) heating boiler, replacing the Eco Radio System remote thermostat.
 
 The solution developed is applicable to all Frisquet boilers marketed until 2012 and fitted with the Eco Radio System module. More recent boilers equipped with the Visio module are not compatible because Frisquet has since implemented encryption in its communication protocol.
 
 The **Frisquet Boiler** component appears as a [Float Output](<https://esphome.io/components/output/>) device.
 
-It is recommended to combine it with the **Heating Curve Climate** component also provided in this project. This [Climate](<https://esphome.io/components/climate/index.html>) component will offer temperature control using an outdoor temperature sensor. If needed, it is also possible to use an other type of Climate component, such as the [PID Climate](https://esphome.io/components/climate/pid.html?highlight=pid).
+It is recommended to combine it with the **Heating Curve Climate** component also provided in this project. This [Climate](<https://esphome.io/components/climate/index.html>) component will offer temperature control using an outdoor temperature sensor. If needed, it is also possible to use an other type of Climate component, such as the [PID Climate](https://esphome.io/components/climate/pid.html).
 
 ## Breaking change in version 1.5
 
@@ -100,7 +99,7 @@ Configuration variables:
 
 - **id** (**Required**, [ID](<https://esphome.io/guides/configuration-types.html#config-id>)): The id to use for this output component.
 - **pin** (**Required**, [Pin](<https://esphome.io/guides/configuration-types.html#config-pin>)): The pin number connected to the boiler.
-- **boiler_id** (**Required**, string): The identifier of your boiler (see below).
+- **boiler_id** (**Required**, string): The identifier of your boiler (see [below](<#boiler-id>)).
 - **calibration_factor** (*Optional*, float): Calibration factor of the boiler. Defaults to `1.9`.
 - **calibration_offset** (*Optional*, float): Calibration offset of the boiler. Defaults to `-41`.
 - All other options from [Float Output](<https://esphome.io/components/output/>).
@@ -116,15 +115,19 @@ The output value received by the component is any rational value between `0` and
 
 `calibration_factor` and  `calibration_offset` are used by the internal sensor to calculate the equivalent water flow temperature out of the output value. The default values have been defined on a *Frisquet Hydroconfort Evolution* boiler.
 
+*Note:* The ``frisquet_boiler`` component will send commands to the boiler right after an update of the ``output`` value and then every 4 minutes. The component must receive regularly updates from the Climate component. To prevent overheating of the boiler, it will stop sending commands to the boiler if the ``output`` value is not updated during 15 minutes. In such case, the boiler will put itself in safe mode.
+
+### Boiler ID
+
 **Important:** the boiler ID that must be indicated in the YAML configuration file is a 4 hexa digit number required to allow
 your boiler to receive the messages from the ESP.
 There are many ways to find your ID:
 
-- by connecting the radio receiver signal wire to an Arduino. See the [frisquet-arduino project](https://github.com/etimou/frisquet-arduino) for more details.
-- by listening with an [RTL-SDR](https://github.com/osmocom/rtl-sdr/) compatible receiver and the [rtl_433 project](https://github.com/merbanan/rtl_433)
-- by opening your receiver and finding the number on the PCB (it is printed on the bottom left!)
+- by connecting the radio receiver signal wire to an Arduino. See the [frisquet-arduino project](https://github.com/etimou/frisquet-arduino) for more details;
+- by listening with an [RTL-SDR](https://github.com/osmocom/rtl-sdr/) compatible receiver and the [rtl_433 project](https://github.com/merbanan/rtl_433);
+- by opening your receiver and finding the number on the PCB (it is printed on the bottom left!).
 
-*Note:* The ``frisquet_boiler`` component will send commands to the boiler right after an update of the ``output``value and then every 4 minutes. The component must receive regularly updates from the Climate component. To prevent overheating of the boiler, it will stop sending commands to the boiler if the ``output`` value is not updated during 15 minutes. In such case, the boiler will put itself in safe mode.
+It is also possible to assign any ID to the boiler by using the configuration mode (see [below](<#frisquet_boiler-switch>)).
 
 ## Heating Curve Climate
 
@@ -132,7 +135,7 @@ In addition, a [Climate](<https://esphome.io/components/climate/index.html>) com
 
 It uses the target, ambiant and outside temperatures and a heating curve formula to calculate a target water temperature, and then calibrates it to the output value.
 
-The [PID Climate](https://esphome.io/components/climate/pid.html?highlight=pid) could be used but it does not provide smooth control and does not anticipate weather evolution.
+The [PID Climate](https://esphome.io/components/climate/pid.html) could be used but it does not provide smooth control and does not anticipate weather evolution.
 
 It is otherwise recommended to use the **Heating Curve Climate** which adjusts the heating power according to the outdoor temperature.
 
@@ -171,7 +174,7 @@ Configuration variables:
   - **ki** (*Optional*, float): The factor for the integral term of the heating curve. May be useful if target temperature can't be reached. Use with caution when the house has a lot of thermal inertia. Defaults to `0`.
 - **output_parameters** (*Optional*): Output parameters of the controller (see [below](<#setpoint-calibration-factors>)).
   - **rounded** (*Optional*, boolean): Forces rounding of the output value to two digits. Defaults to `false`.
-  - **minimum_output** (*Optional*, float): Output value below which output value is set to zero. Defaults to `0.1`.
+  - **minimum_output** (*Optional*, float): Output value below which output value is set to zero. Defaults to `0`.
   - **maximum_output** (*Optional*, float): Output value above which output value won't go (cap). Defaults to `1`.
   - **heat_required_output** (*Optional*, float): Minimum output value to be considered when the [*Heat Required* switch](#heat_curve_climate-switch) is on.  Defaults to `0.1`.
   - **output_factor** (*Optional*, float): Calibration factor of the output. Defaults to `1`.
@@ -294,11 +297,11 @@ If you are not using Home Assistant, you can use any local temperature sensor co
 
 *Note:* Sensors should have a regular update interval as the heat curve update frequency is tied to the update interval of the sensors. We recommend putting a filter on the sensors to filter out the noise to ensure better stability of the output.
 
-## `frisquet_boiler` Switch
+## `frisquet_boiler` Switches
 
-The original Eco Radio System remote provides two setup modes : configuration and testing. You can action these modes by a long press on the up or down arrow buttons.
+The original Eco Radio System remote provides two setup modes : **configuration** and **testing**. You can enter these modes by a long press on the up or down arrow buttons.
 
-Similar setup modes are available and control swiches can be added with the following code:
+Similar setup modes are available with the `frisquet_boiler`component. Control swiches to enter those modes can be added with the following lines of code:
 
 ```yaml
 switch:
@@ -311,11 +314,13 @@ switch:
 
 ### Configuration mode
 
-When in **configuration mode**, press and hold the "manual mode" button (hand-shaped icon) on the boiler's control panel for 5 seconds; the manual control indicator blinks, indicating that it is receiving the radio transmission. 
+When in **configuration mode**, press and hold the *manual mode* button (hand-shaped icon) on the boiler's control panel for 5 seconds; the manual control indicator blinks, indicating that it is receiving the radio transmission.
 
 Release and press the button with the hand-shaped icon for 2 seconds to confirm the transmission.
 
-This procedure allows to associate an arbitrary ID to your boiler. This can be helpful if you have no remote control associated with the boiler.
+You can then quit the configuration mode.
+
+This procedure allows to associate an arbitrary ID to your boiler. This can be helpful if no remote control was previously associated with the boiler.
 
 ### Test mode
 
@@ -392,7 +397,7 @@ Those sensors may be useful to set up your heating curve `control_parameters`.
 
 ## `climate.heat_curve.set_control_parameters` Action
 
-This [action](<https://esphome.io/automations/actions?highlight=automation#actions>) sets new values for the control parameters. This can be used to manually tune the controller. Make sure to update the values you want on the YAML file! They will reset on the next reboot.
+This [action](<https://esphome.io/automations/actions#actions>) sets new values for the control parameters. This can be used to manually tune the controller. Make sure to update the values you want on the YAML file! They will reset on the next reboot.
 
 ```yaml
 on_...:
@@ -414,7 +419,7 @@ Configuration variables:
 
 ## `climate.pid.reset_integral_term` Action
 
-This [action](<https://esphome.io/automations/actions?highlight=automation#actions>) resets the integral term of the PID controller to 0. This might be necessary under certain conditions to avoid the control loop to overshoot (or undershoot) a target.
+This [action](<https://esphome.io/automations/actions#actions>) resets the integral term of the PID controller to 0. This might be necessary under certain conditions to avoid the control loop to overshoot (or undershoot) a target.
 
 ```yaml
 on_...:
@@ -428,7 +433,7 @@ Configuration variables:
 
 ## `boiler.set_mode` Action
 
-This [action](<https://esphome.io/automations/actions?highlight=automation#actions>) sets the boiler operating mode.
+This [action](<https://esphome.io/automations/actions#actions>) sets the boiler operating mode.
 This parameter is actually included in the frames sent to the boiler but I haven't seen any significant effect of the setting.
 
 ```yaml
@@ -448,7 +453,7 @@ Configuration variables:
 
 The `frisquet_boiler` Output component also inherits actions from [Float Output](<https://esphome.io/components/output/>) and in particular [`output.set_level`](<https://esphome.io/components/output/#output-set-level-action>).
 
-This [action](<https://esphome.io/automations/actions?highlight=automation#actions>) sets the float output to the given level when executed. This can be usefull to set the boiler output if it is not connected to a Climate component.
+This [action](<https://esphome.io/automations/action#actions>) sets the float output to the given level when executed. This can be usefull to set the boiler output if it is not connected to a Climate component.
 
 ```yaml
 on_...:
@@ -469,7 +474,7 @@ The Heating Curve Climate component automatically appears in Home Assistant as a
 
 Also, when using the [native API](<https://esphome.io/components/api.html>) with Home Assistant, it is also possible to get data from Home Assistant to ESPHome with [user-defined services](<https://esphome.io/components/api.html#api-services>). When you declare services in your ESPHome YAML file, they will automatically show up in Home Assistant and you can call them directly.
 
-This way it is possible to call the [actions](<https://esphome.io/automations/actions?highlight=automation#actions>) provided by the Boiler Output and Heating Curve Climate components:
+This way it is possible to call the [actions](<https://esphome.io/automations/actions=automation#actions>) provided by the Boiler Output and Heating Curve Climate components:
 
 ```yaml
 # Example configuration entry

--- a/README.md
+++ b/README.md
@@ -109,9 +109,7 @@ If `min_power`is set to a value that is not zero, it is important to set `zero_m
 The output value received by the component is any rational value between `0` and `1`. Internaly, the output value is multiplied by 100 and rounded to an integer value because the Frisquet Boiler only accepts orders as integers between 0 and 100:
 
 - 0 : boiler is stopped
-- 10 : for some boilers, water pump starts with no heating, for others heating starts with any value > 0
-- 11 - 100 : water heating
-- 15 : for some reason, the value is not accepted by the boiler. Internally, 15 is converted to 16 to avoid this case.
+- 01 - 100 : water heating
 
 `calibration_factor` and  `calibration_offset` are used by the internal sensor to calculate the equivalent water flow temperature out of the output value. The default values have been defined on a *Frisquet Hydroconfort Evolution* boiler.
 
@@ -127,7 +125,7 @@ There are many ways to find your ID:
 - by listening with an [RTL-SDR](https://github.com/osmocom/rtl-sdr/) compatible receiver and the [rtl_433 project](https://github.com/merbanan/rtl_433);
 - by opening your receiver and finding the number on the PCB (it is printed on the bottom left!).
 
-It is also possible to assign any ID to the boiler by using the configuration mode (see [below](<#frisquet_boiler-switch>)).
+It is also possible to assign any ID to the boiler using configuration mode (see [below](<#frisquet_boiler-switch>)).
 
 ## Heating Curve Climate
 
@@ -301,7 +299,7 @@ If you are not using Home Assistant, you can use any local temperature sensor co
 
 The original Eco Radio System remote provides two setup modes : **configuration** and **testing**. You can enter these modes by a long press on the up or down arrow buttons.
 
-Similar setup modes are available with the `frisquet_boiler`component. Control swiches to enter those modes can be added with the following lines of code:
+Those configuration modes are also available with the `frisquet_boiler`component. Control swiches to access these modes can be added with the following lines of code:
 
 ```yaml
 switch:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The output value received by the component is any rational value between `0` and
 **Important:** the boiler ID that must be indicated in the YAML configuration file is a 4 hexa digit number required to allow
 your boiler to receive the messages from the ESP.
 There are many ways to find your ID:
+
 - by connecting the radio receiver signal wire to an Arduino. See the [frisquet-arduino project](https://github.com/etimou/frisquet-arduino) for more details.
 - by listening with an [RTL-SDR](https://github.com/osmocom/rtl-sdr/) compatible receiver and the [rtl_433 project](https://github.com/merbanan/rtl_433)
 - by opening your receiver and finding the number on the PCB (it is printed on the bottom left!)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Some parameters names and behaviour have changed in version 1.5. The parameters 
 
 Whilst `slope` provides the same functionnality as `heat_factor`, `shift` is slightly different. One way to define `shift` is to take the `offset` value you were previously using and substract your usual setpoint temperature (`shift` = `offset` - `setpoint`). Negative values are accepted.
 
-The same changes are applicable to the component [actions](<https://esphome.io/guides/automations.html?highlight=automation#actions>) and component [sensors](<#heat_curve_climate-sensor>).
+The same changes are applicable to the component [actions](<https://esphome.io/automations/actions?highlight=automation#actions>) and component [sensors](<#heat_curve_climate-sensor>).
 
 ## References
 
@@ -193,7 +193,7 @@ where :
 
 In this example, heating curves are given for an ambiant temperature (target) of 20°C with no shift. The `shift`parameter allows you to move up and down the curves by a few degrees.
 
-`slope`and `shift`strongly depend on the heat insulation of the house. Therefore slight adjustments may be necessary to find the best settings. Guidelines to do so can be found [here](https://blog.elyotherm.fr/2013/08/reglage-optimisation-courbe-de-chauffe.html) (French).
+`slope`and `shift`strongly depend on the heat insulation of the house. Therefore slight adjustments may be necessary to find the best settings.
 In order to ease the fine tuning of those parameters, a service can be set in Home Assistant to change the parameters without restarting ESPHome ([see below](<#integration-with-home-assistant>)).
 
 The following standard values for the `slope` may be used as a guide:
@@ -391,7 +391,7 @@ Those sensors may be useful to set up your heating curve `control_parameters`.
 
 ## `climate.heat_curve.set_control_parameters` Action
 
-This [action](<https://esphome.io/guides/automations.html?highlight=automation#actions>) sets new values for the control parameters. This can be used to manually tune the controller. Make sure to update the values you want on the YAML file! They will reset on the next reboot.
+This [action](<https://esphome.io/automations/actions?highlight=automation#actions>) sets new values for the control parameters. This can be used to manually tune the controller. Make sure to update the values you want on the YAML file! They will reset on the next reboot.
 
 ```yaml
 on_...:
@@ -413,7 +413,7 @@ Configuration variables:
 
 ## `climate.pid.reset_integral_term` Action
 
-This [action](<https://esphome.io/guides/automations.html?highlight=automation#actions>) resets the integral term of the PID controller to 0. This might be necessary under certain conditions to avoid the control loop to overshoot (or undershoot) a target.
+This [action](<https://esphome.io/automations/actions?highlight=automation#actions>) resets the integral term of the PID controller to 0. This might be necessary under certain conditions to avoid the control loop to overshoot (or undershoot) a target.
 
 ```yaml
 on_...:
@@ -427,7 +427,7 @@ Configuration variables:
 
 ## `boiler.set_mode` Action
 
-This action sets the boiler operating mode.
+This [action](<https://esphome.io/automations/actions?highlight=automation#actions>) sets the boiler operating mode.
 This parameter is actually included in the frames sent to the boiler but I haven't seen any significant effect of the setting.
 
 ```yaml
@@ -447,7 +447,7 @@ Configuration variables:
 
 The `frisquet_boiler` Output component also inherits actions from [Float Output](<https://esphome.io/components/output/>) and in particular [`output.set_level`](<https://esphome.io/components/output/#output-set-level-action>).
 
-This action sets the float output to the given level when executed. This can be usefull to set the boiler output if it is not connected to a Climate component.
+This [action](<https://esphome.io/automations/actions?highlight=automation#actions>) sets the float output to the given level when executed. This can be usefull to set the boiler output if it is not connected to a Climate component.
 
 ```yaml
 on_...:
@@ -468,13 +468,13 @@ The Heating Curve Climate component automatically appears in Home Assistant as a
 
 Also, when using the [native API](<https://esphome.io/components/api.html>) with Home Assistant, it is also possible to get data from Home Assistant to ESPHome with [user-defined services](<https://esphome.io/components/api.html#api-services>). When you declare services in your ESPHome YAML file, they will automatically show up in Home Assistant and you can call them directly.
 
-This way it is possible to call the [Actions](<https://esphome.io/guides/automations.html?highlight=automation#actions>) provided by the Boiler Output and Heating Curve Climate components:
+This way it is possible to call the [actions](<https://esphome.io/automations/actions?highlight=automation#actions>) provided by the Boiler Output and Heating Curve Climate components:
 
 ```yaml
 # Example configuration entry
 api:
-  services:
-    - service: set_boiler_setpoint
+  actions:
+    - action: set_boiler_setpoint
       variables:
         setpoint: int
       then:
@@ -482,7 +482,7 @@ api:
             id: boiler_cmd
             level: !lambda 'return setpoint / 100.0;'
 
-    - service: set_boiler_mode
+    - action: set_boiler_mode
       variables:
         mode: int
       then:
@@ -490,7 +490,7 @@ api:
             id: boiler_cmd
             mode: !lambda 'return mode;'
 
-    - service: set_control_parameters
+    - action: set_control_parameters
       variables:
         slope: float
         shift: float
@@ -504,12 +504,12 @@ api:
         - climate.heat_curve.reset_integral_term: boiler_climate
 ```
 
-Those lines in the YAML file will expose three [services](https://www.home-assistant.io/docs/scripts/service-calls/) in Home Assistant that can be called with the following lines (provided that the ESP device name is `myFrisquetBoiler`):
+Those lines in the YAML file will expose three [actions](https://www.home-assistant.io/docs/scripts/perform-actions/) in Home Assistant that can be called with the following lines (provided that the ESP device name is `myFrisquetBoiler`):
 
 ### Set climate control parameters
 
 ```yaml
-service: esphome.myFrisquetBoiler_set_control_parameters
+action: esphome.myFrisquetBoiler_set_control_parameters
 data:
   slope: 1.2
   shift: 3
@@ -519,7 +519,7 @@ data:
 ### Set boiler setpoint Service
 
 ```yaml
-service: esphome.myFrisquetBoiler_set_boiler_setpoint
+action: esphome.myFrisquetBoiler_set_boiler_setpoint
 data:
   level: 50
 ```
@@ -527,7 +527,7 @@ data:
 ### Set boiler mode Service
 
 ```yaml
-service: esphome.myFrisquetBoiler_set_boiler_mode
+action: esphome.myFrisquetBoiler_set_boiler_mode
 data:
   mode: 3
 ```

--- a/boiler.yaml
+++ b/boiler.yaml
@@ -134,8 +134,8 @@ switch:
     name: "Heat Required"
 
 api:
-  services:
-    - service: set_boiler_setpoint
+  actions:
+    - action: set_boiler_setpoint
       variables:
         setpoint: int
       then:
@@ -143,7 +143,7 @@ api:
             id: boiler_cmd
             level: !lambda 'return setpoint / 100.0;'
 
-    - service: set_boiler_mode
+    - action: set_boiler_mode
       variables:
         mode: int
       then:
@@ -151,7 +151,7 @@ api:
             id: boiler_cmd
             mode: !lambda 'return mode;'
             
-    - service: set_control_parameters
+    - action: set_control_parameters
       variables:
         slope: float
         shift: float

--- a/components/frisquet_boiler/frisquet_boiler.cpp
+++ b/components/frisquet_boiler/frisquet_boiler.cpp
@@ -46,8 +46,8 @@ void FrisquetBoiler::write_state(float state) {
   int new_demand = round(state * 100);
 
   // Cmd = 15 is known as not working
-  if (new_demand == 15)
-    new_demand = 16;
+  // if (new_demand == 15)
+  //   new_demand = 16;
 
   this->last_order_ = millis();
 

--- a/components/heat_curve_climate/climate.py
+++ b/components/heat_curve_climate/climate.py
@@ -62,7 +62,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_ROUNDED_OUPUT, default=False): cv.boolean,
                     cv.Optional(CONF_OUTPUT_FACTOR, default=1): cv.float_,
                     cv.Optional(CONF_OUTPUT_OFFSET, default=0): cv.float_,
-                    cv.Optional(CONF_MINIMUM_OUTPUT, default=0.1): cv.float_,
+                    cv.Optional(CONF_MINIMUM_OUTPUT, default=0.0): cv.float_,
                     cv.Optional(CONF_MAXIMUM_OUTPUT, default=1.0): cv.float_,
                     cv.Optional(CONF_HEATREQ_OUTPUT, default=0.1): cv.float_,
                 }

--- a/components/heat_curve_climate/heat_curve_climate.h
+++ b/components/heat_curve_climate/heat_curve_climate.h
@@ -85,7 +85,7 @@ class HeatingCurveClimate : public Climate, public Component {
   float outdoor_temp_{NAN};
   float output_calibration_factor_{1};
   float output_calibration_offset_{0};
-  float minimum_output_{0.1};
+  float minimum_output_{0};
   float maximum_output_{1};
   float heat_required_output_{0.1};
   float min_delta_{2.0};

--- a/components/heat_curve_climate/sensor/heat_curve_sensor.h
+++ b/components/heat_curve_climate/sensor/heat_curve_sensor.h
@@ -21,16 +21,14 @@ enum HeatCurveClimateSensorType {
   PID_SENSOR_TYPE_KI
 };
 
-class HeatCurveClimateSensor : public sensor::Sensor, public Component {
+class HeatCurveClimateSensor : public sensor::Sensor, public Component, public Parented<HeatingCurveClimate> {
  public:
   void setup() override;
-  void set_parent(HeatingCurveClimate *parent) { parent_ = parent; }
   void set_type(HeatCurveClimateSensorType type) { type_ = type; }
   void dump_config() override;
 
  protected:
   void update_from_parent_();
-  HeatingCurveClimate *parent_;
   HeatCurveClimateSensorType type_;
 };
 

--- a/components/heat_curve_climate/switch/heat_curve_switch.h
+++ b/components/heat_curve_climate/switch/heat_curve_switch.h
@@ -8,14 +8,12 @@ namespace esphome {
 namespace climate {
 namespace heat_curve {
 
-class HeatCurveClimateSwitch : public switch_::Switch, public Component {
+class HeatCurveClimateSwitch : public switch_::Switch, public Component, public Parented<HeatingCurveClimate> {
  public:
-  void set_parent(HeatingCurveClimate *parent) { parent_ = parent; }
   void dump_config() override;
 
  protected:
   void write_state(bool state) override;
-  HeatingCurveClimate *parent_;
 };
 
 }  // namespace heat_curve

--- a/doc/frisquet_boiler.rst
+++ b/doc/frisquet_boiler.rst
@@ -102,17 +102,10 @@ Internally, the output value is multiplied by 100 and rounded to an integer valu
 only accepts orders as integers between 0 and 100:
 
 - 0 : boiler is stopped
-- 10 : for some boilers, water pump starts with no heating, for others heating starts with any value > 0
-- 11 - 100 : water heating
-- 15 : for some reason, the value is not accepted by the boiler. Internally, 15 is converted to 16 to avoid this case.
+- 01 - 100 : water heating
 
 Boiler ID
 ---------
-
-**Important:** the boiler ID that must be indicated in the configuration variables is required to allow your boiler to receive the messages 
-from the ESPome device. This ID can be retrieved by connecting the radio receiver signal wire to an Arduino or an ESP device.
-See `here <https://github.com/etimou/frisquet-arduino>`__ for more details.
-
 
 **Important:** the boiler ID that must be indicated in the YAML configuration file is a 4 hexa digit number required 
 to allow your boiler to receive the messages from the ESPHome device. There are many ways to find your ID:
@@ -120,6 +113,8 @@ to allow your boiler to receive the messages from the ESPHome device. There are 
 - by connecting the radio receiver signal wire to an Arduino. See the `frisquet-arduino project <https://github.com/etimou/frisquet-arduino>`__ for more details.
 - by listening with an `RTL-SDR <https://github.com/osmocom/rtl-sdr/>`__ compatible receiver and the `rtl_433 project <https://github.com/merbanan/rtl_433>`__
 - by opening your receiver and finding the number on the PCB (it is printed on the bottom left!)
+
+It is also possible to assign any ID to the boiler using configuration mode (see below).
 
 .. warning::
 

--- a/doc/frisquet_boiler.rst
+++ b/doc/frisquet_boiler.rst
@@ -180,7 +180,7 @@ Two setup mode switches can be added to control the Configuration and Test modes
 Configuration mode
 ******************
 
-When in **configuration mode**, press and hold the "manual mode" button (hand-shaped icon) on the boiler's 
+When in **configuration mode**, press and hold the *manual mode* button (hand-shaped icon) on the boiler's 
 control panel for 5 seconds; the manual control indicator blinks, indicating that it is receiving the 
 radio transmission. 
 
@@ -188,6 +188,9 @@ Release and press the button with the hand-shaped icon for 2 seconds to confirm 
 
 This procedure allows to associate an arbitrary ID to your boiler. This can be helpful if you have 
 no remote control associated with the boiler.
+
+This procedure allows to associate an arbitrary ID to your boiler. This can be helpful if no remote 
+control was previously associated with the boiler.
 
 Test mode
 *********

--- a/doc/heat_curve_climate.rst
+++ b/doc/heat_curve_climate.rst
@@ -7,6 +7,10 @@ Heating Curve Climate
     :description: Instructions for setting up Heating Curve climate controllers with ESPHome.
 
 The ``heating_curve_climate``component provides temperature control based on a heating curve and the outdoor temperature.
+
+It uses the target, ambiant and outside temperatures and a heating curve formula to calculate a target water temperature, 
+and then calibrates it to the output value.
+
 It has been developped to be used with the :doc:`/components/output/frisquet_boiler` component but can be used with any kind 
 of heating :doc:`/components/output/index`.
 


### PR DESCRIPTION
The boiler actually take all order from 0 to 100. So now :
- default minimum output = 0
- cmd=15 is now accepted
- README is updated accordingly

In addition, yaml syntax for HA automations is updated to the new standards.